### PR TITLE
I18n implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ELFIM (_pronounced "elf eye em"_) is a light-weight event logging plugin that posts selected events to Slack and Discord. It's a convenient way to keep track of who logged on when, or what commands they used while playing.
 
+__NOTE:__ Version 2.3.0 adds Internationalization support (with an included localized German properties file). I'd love for non-English speakers to contribute translations.
+
 #### Available at
 - [PaperMC](https://hangar.papermc.io/HideTheMonkey/EventLoggerForIM)
 - [SpigotMC](https://www.spigotmc.org/resources/eventloggerforim.118800/)
@@ -51,6 +53,19 @@ logServerProperties:
   - level-type
 ```
 
+Configure the language to use in the interface:
+```yaml
+# Specify the locale to use for messages (NOTE: must have a corresponding locale file in the plugin config folder)
+# example: ./plugins/EventLoggerForIM/i18n/en_US.properties or ./plugins/EventLoggerForIM/i18n/de.properties
+locale: en_US
+
+```
+To add a new translation, duplicate `en_US.properties` and save it with a new locale-specific filename using UTF-8 encoding (e.g., `ja_JP.properties`), and update the values accordingly. Then, set `locale: ja_JP` in config.yml to enable your new translations to appear in generated messages.
+
+If you would like your translation to be included in this project, please open an issue on GitHub and attach the translated file. I will review and integrate it as appropriate.
+
+__NOTE:__ The included `de.properties` file was generated using AI and may contain inaccuracies. Contributions from native German speakers to improve this translation are welcome and appreciated.
+
 ## Slack Configuration and Examples
 
 See the [Slack readme](./resources/Slack.md).
@@ -73,7 +88,6 @@ _The metrics can be disabled in config.yml if you really want, but please consid
 
 ## Potential Updates
 
-- Internationalize / Localize text strings
 - Add ability for players to send private messages to admins (From MC to Slack/Discord)
 - Address Discord's rate limiting issue with webhooks.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.hidethemonkey.elfim</groupId>
   <artifactId>ELFIM</artifactId>
-  <version>2.2.12</version>
+  <version>2.2.13</version>
   <packaging>jar</packaging>
 
   <name>Event Logger For IM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.hidethemonkey.elfim</groupId>
   <artifactId>ELFIM</artifactId>
-  <version>2.2.13</version>
+  <version>2.3.0</version>
   <packaging>jar</packaging>
 
   <name>Event Logger For IM</name>

--- a/src/main/java/com/hidethemonkey/elfim/ELConfig.java
+++ b/src/main/java/com/hidethemonkey/elfim/ELConfig.java
@@ -23,18 +23,18 @@
  */
 package com.hidethemonkey.elfim;
 
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.MemorySection;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.MemorySection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
 
 public class ELConfig {
   private final FileConfiguration config;

--- a/src/main/java/com/hidethemonkey/elfim/ELConfig.java
+++ b/src/main/java/com/hidethemonkey/elfim/ELConfig.java
@@ -270,6 +270,13 @@ public class ELConfig {
     return ELConfig.updateAvailable;
   }
 
+  /**
+   * @return the locale set in config.yml
+   */
+  public String getLocale() {
+    return config.getString("locale");
+  }
+
   ////////////////////////////////////////////////
   // Slack
   ////////////////////////////////////////////////

--- a/src/main/java/com/hidethemonkey/elfim/ELFIM.java
+++ b/src/main/java/com/hidethemonkey/elfim/ELFIM.java
@@ -23,23 +23,27 @@
  */
 package com.hidethemonkey.elfim;
 
+import java.util.Objects;
+
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.bstats.bukkit.Metrics;
+import org.bstats.charts.SimplePie;
+import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.java.JavaPlugin;
+
 import com.hidethemonkey.elfim.commands.CommandELFS;
 import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.VersionChecker;
 import com.hidethemonkey.elfim.helpers.VersionData;
 import com.hidethemonkey.elfim.listeners.PlayerListeners;
 import com.hidethemonkey.elfim.listeners.ServerListeners;
-import com.hidethemonkey.elfim.messaging.*;
+import com.hidethemonkey.elfim.messaging.DiscordPlayerHandler;
+import com.hidethemonkey.elfim.messaging.DiscordServerHandler;
+import com.hidethemonkey.elfim.messaging.PlayerHandlerInterface;
+import com.hidethemonkey.elfim.messaging.ServerHandlerInterface;
+import com.hidethemonkey.elfim.messaging.SlackPlayerHandler;
+import com.hidethemonkey.elfim.messaging.SlackServerHandler;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessageFactory;
-
-import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-
-import org.bstats.bukkit.Metrics;
-import org.bstats.charts.SimplePie;
-import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.java.JavaPlugin;
-
-import java.util.Objects;
 
 public class ELFIM extends JavaPlugin {
 
@@ -64,6 +68,7 @@ public class ELFIM extends JavaPlugin {
     ELConfig.updateConfig(this);
     saveDefaultConfig();
     saveResource("i18n/en_US.properties", true);
+    saveResource("i18n/de.properties", true);
 
     ELConfig elConfig = new ELConfig(this.getConfig(), getLogger());
 

--- a/src/main/java/com/hidethemonkey/elfim/ELFIM.java
+++ b/src/main/java/com/hidethemonkey/elfim/ELFIM.java
@@ -24,6 +24,7 @@
 package com.hidethemonkey.elfim;
 
 import com.hidethemonkey.elfim.commands.CommandELFS;
+import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.VersionChecker;
 import com.hidethemonkey.elfim.helpers.VersionData;
 import com.hidethemonkey.elfim.listeners.PlayerListeners;
@@ -45,6 +46,7 @@ public class ELFIM extends JavaPlugin {
   private DiscordMessageFactory messageFactory;
   private Metrics metrics;
   private VersionData versionData;
+  private Localizer localizer;
 
   /**
    * 
@@ -61,11 +63,15 @@ public class ELFIM extends JavaPlugin {
   public void onEnable() {
     ELConfig.updateConfig(this);
     saveDefaultConfig();
+    saveResource("i18n/en_US.properties", true);
 
     ELConfig elConfig = new ELConfig(this.getConfig(), getLogger());
 
     // Store name on config for easy access later (not saved to file)
     elConfig.setPluginName(this.getName());
+
+    this.localizer = new Localizer(this.getConfig().getCurrentPath() + "plugins/" + this.getName(),
+        elConfig.getLocale());
 
     // Check for new versions
     compareVersions();
@@ -82,10 +88,10 @@ public class ELFIM extends JavaPlugin {
         registerServerListeners(ELConfig.SLACK, elConfig, getServer().getPluginManager());
         registerPlayerListeners(ELConfig.SLACK, elConfig, advConfig, getServer().getPluginManager());
       } else {
-        getLogger().warning("The Slack API token or channel is not configured!");
+        getLogger().warning(localizer.t("slack.warn.api_not_configured"));
       }
     } else {
-      getLogger().info("Slack integration is not enabled.");
+      getLogger().info(localizer.t("slack.info.not_enabled"));
     }
 
     // DISCORD
@@ -94,7 +100,7 @@ public class ELFIM extends JavaPlugin {
       registerServerListeners(ELConfig.DISCORD, elConfig, getServer().getPluginManager());
       registerPlayerListeners(ELConfig.DISCORD, elConfig, advConfig, getServer().getPluginManager());
     } else {
-      getLogger().info("Discord integration is not enabled.");
+      getLogger().info(localizer.t("discord.info.not_enabled"));
     }
 
     // Register configuration commands
@@ -115,6 +121,15 @@ public class ELFIM extends JavaPlugin {
    */
   public Metrics getMetrics() {
     return metrics;
+  }
+
+  /**
+   * Gets the localizer for translation.
+   * 
+   * @return
+   */
+  public Localizer getLocalizer() {
+    return localizer;
   }
 
   /**
@@ -212,10 +227,12 @@ public class ELFIM extends JavaPlugin {
               .toString(config.getLogPlayerTeleport(ELConfig.DISCORD));
         }));
 
+        this.metrics.addCustomChart(new SimplePie("translation_locale", () -> {
+          return localizer.getLocale();
+        }));
+
       } else {
-        getLogger()
-            .info(
-                "bStats is not enabled! Please consider activating this service to help me keep track of ELFIM usage. 🙇");
+        getLogger().info(localizer.t("metrics.info.not_enabled"));
       }
     }
   }
@@ -291,7 +308,7 @@ public class ELFIM extends JavaPlugin {
    */
   private boolean checkSlackChannel(String channelId) {
     if (channelId.isBlank() || channelId.equals(ELConfig.REPLACE_ME)) {
-      getLogger().severe("The Slack channel must be set in /plugin/EventLoggerForIM/config.yml!");
+      getLogger().severe(localizer.t("slack.error.channel_not_set"));
       return false;
     }
     return true;
@@ -303,7 +320,7 @@ public class ELFIM extends JavaPlugin {
    */
   private boolean checkSlackToken(String token) {
     if (token.isBlank() || token.equals(ELConfig.REPLACE_ME)) {
-      getLogger().severe("The Slack API token must be set in /plugin/EventLoggerForIM/config.yml!");
+      getLogger().severe(localizer.t("slack.error.token_not_set"));
       return false;
     }
     return true;
@@ -315,10 +332,10 @@ public class ELFIM extends JavaPlugin {
    */
   private ServerHandlerInterface getServerHandler(String service) {
     if (service.equals(ELConfig.SLACK)) {
-      return new SlackServerHandler();
+      return new SlackServerHandler(localizer);
     }
     if (service.equals(ELConfig.DISCORD)) {
-      return new DiscordServerHandler(messageFactory);
+      return new DiscordServerHandler(messageFactory, localizer);
     }
     return null;
   }
@@ -329,10 +346,10 @@ public class ELFIM extends JavaPlugin {
    */
   private PlayerHandlerInterface getPlayerHandler(String service) {
     if (service.equals(ELConfig.SLACK)) {
-      return new SlackPlayerHandler();
+      return new SlackPlayerHandler(localizer);
     }
     if (service.equals(ELConfig.DISCORD)) {
-      return new DiscordPlayerHandler(messageFactory);
+      return new DiscordPlayerHandler(messageFactory, localizer);
     }
     return null;
   }
@@ -342,8 +359,7 @@ public class ELFIM extends JavaPlugin {
   */
   private void compareVersions() {
     if (versionData == null) {
-      getLogger().warning(
-          "Could not check for new versions. Please see https://hangar.papermc.io/HideTheMonkey/EventLoggerForIM for updates.");
+      getLogger().warning(localizer.t("version.check_failed"));
       return;
     }
     DefaultArtifactVersion latestVersion = new DefaultArtifactVersion(versionData.getVersion());
@@ -351,13 +367,13 @@ public class ELFIM extends JavaPlugin {
     if (latestVersion.compareTo(currentVersion) > 0) {
       ELConfig.setUpdateAvailable(true);
       getLogger().warning("****************************************************************************");
-      getLogger().warning("* A new release of EventLoggerForIM is available!");
+      getLogger().warning("* " + localizer.t("version.new_release_available"));
       getLogger().warning("*");
-      getLogger().warning("* New version: " + versionData.getVersion());
-      getLogger().warning("* Your version: " + getPluginMeta().getVersion());
+      getLogger().warning("* " + localizer.t("version.new_version", versionData.getVersion()));
+      getLogger().warning("* " + localizer.t("version.your_version", getPluginMeta().getVersion()));
       getLogger().warning("*");
-      getLogger().warning("* Please update to take advantage of the latest features and bug fixes.");
-      getLogger().warning("* Download here: https://hangar.papermc.io/HideTheMonkey/EventLoggerForIM");
+      getLogger().warning("* " + localizer.t("version.please_update"));
+      getLogger().warning("* " + localizer.t("version.download_link", versionData.getDownloadUrl()));
       getLogger().warning("****************************************************************************");
     }
   }

--- a/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 HideTheMonkey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.hidethemonkey.elfim.helpers;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Locale;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+public class Localizer {
+    private static final String DEFAULT_LOCALE = "en_US";
+    private static final String SUFFIX = ".properties";
+    private Properties properties;
+    private String configPath = "";
+    private String locale = "";
+    private Locale localeClass;
+
+    public Localizer(String pluginPath, String locale) {
+        this.configPath = pluginPath + "/i18n/";
+        this.locale = locale;
+        this.localeClass = Locale.forLanguageTag(locale);
+        // Load properties from the configured locale
+        properties = loadTranslations();
+    }
+
+    /**
+     * @return the configured locale
+     */
+    public String getLocale() {
+        return this.locale;
+    }
+
+    /**
+     * t is for translate
+     * 
+     * @param key
+     * @return
+     */
+    public String t(String key) {
+        return properties.getProperty(key, key);
+    }
+
+    public String t(String key, Object... args) {
+        String template = t(key);
+        return String.format(this.localeClass, template, args);
+    }
+
+    /**
+     * Load the translation strings from a properties file in the config dir
+     * 
+     * @return Properties with translation strings
+     */
+    private Properties loadTranslations() {
+        Properties properties = new Properties();
+        Path path = Paths.get(this.configPath + this.locale + SUFFIX);
+        if (!Files.exists(path)) {
+            path = Paths.get(this.configPath + this.locale.split("_")[0] + SUFFIX);
+            if (!Files.exists(path)) {
+                path = Paths.get(this.configPath + DEFAULT_LOCALE + SUFFIX);
+            }
+        }
+        try (InputStream input = new FileInputStream(path.toString())) {
+            properties.load(input);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return properties;
+    }
+}

--- a/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
@@ -69,6 +69,13 @@ public class Localizer {
         return properties.getProperty(key, key);
     }
 
+    /**
+     * t is for translate
+     * 
+     * @param key
+     * @param args
+     * @return
+     */
     public String t(String key, Object... args) {
         String template = t(key);
         return String.format(this.localeClass, template, args);
@@ -90,13 +97,14 @@ public class Localizer {
         }
         try (InputStream input = new FileInputStream(path.toString())) {
             Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8);
-            props.load(reader);  // Use load(Reader) to support UTF-8
+            props.load(reader); // Use load(Reader) to support UTF-8
         } catch (IOException e) {
             // Try to load default one more time
             try (InputStream input = new FileInputStream(configPath + DEFAULT_LOCALE + SUFFIX)) {
                 Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8);
-                props.load(reader);  // Use load(Reader) to support UTF-8
+                props.load(reader); // Use load(Reader) to support UTF-8
             } catch (IOException ex) {
+                // ignore
             }
         }
         return props;

--- a/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java
@@ -96,7 +96,7 @@ public class Localizer {
             try (InputStream input = new FileInputStream(configPath + DEFAULT_LOCALE + SUFFIX)) {
                 Reader reader = new InputStreamReader(input, StandardCharsets.UTF_8);
                 props.load(reader);  // Use load(Reader) to support UTF-8
-            }catch (IOException ex) {
+            } catch (IOException ex) {
             }
         }
         return props;

--- a/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
@@ -54,6 +54,9 @@ public class VersionChecker {
         } catch (IOException | InterruptedException e) {
             // do nothing
         }
+        finally {
+            client.close();
+        }
         return version;
     }
 }

--- a/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
@@ -40,10 +40,9 @@ public class VersionChecker {
                 .uri(URI.create("https://api.github.com/repos/hidethemonkey/EventLoggerForIM/releases/latest"))
                 .build();
 
-        HttpResponse<String> response;
         VersionData version = null;
         try {
-            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response != null && response.statusCode() == 200) {
                 JSONObject obj = new JSONObject(response.body());
@@ -51,10 +50,8 @@ public class VersionChecker {
                         obj.getJSONArray("assets").getJSONObject(0).getString("browser_download_url"),
                         obj.getString("published_at"));
             }
+            client.close();
         } catch (IOException | InterruptedException e) {
-            // do nothing
-        }
-        finally {
             client.close();
         }
         return version;

--- a/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
+++ b/src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java
@@ -50,8 +50,10 @@ public class VersionChecker {
                         obj.getJSONArray("assets").getJSONObject(0).getString("browser_download_url"),
                         obj.getString("published_at"));
             }
-            client.close();
         } catch (IOException | InterruptedException e) {
+            // do nothing
+        }
+        finally {
             client.close();
         }
         return version;

--- a/src/main/java/com/hidethemonkey/elfim/messaging/DiscordPlayerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/DiscordPlayerHandler.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import com.hidethemonkey.elfim.AdvancementConfig;
 import com.hidethemonkey.elfim.ELConfig;
 import com.hidethemonkey.elfim.ELFIM;
+import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.StringUtils;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessage;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessageFactory;
@@ -51,7 +52,8 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   private final Gson gson = new Gson();
   private DiscordMessageFactory messageFactory;
 
-  public DiscordPlayerHandler(DiscordMessageFactory messageFactory) {
+  public DiscordPlayerHandler(DiscordMessageFactory messageFactory, Localizer localizer) {
+    super(localizer);
     this.messageFactory = messageFactory;
   }
 

--- a/src/main/java/com/hidethemonkey/elfim/messaging/DiscordPlayerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/DiscordPlayerHandler.java
@@ -23,6 +23,18 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
+import java.util.logging.Logger;
+
+import org.bstats.charts.SimplePie;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerRespawnEvent.RespawnReason;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
 import com.google.gson.Gson;
 import com.hidethemonkey.elfim.AdvancementConfig;
 import com.hidethemonkey.elfim.ELConfig;
@@ -32,25 +44,15 @@ import com.hidethemonkey.elfim.helpers.StringUtils;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessage;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessageFactory;
 import com.hidethemonkey.elfim.messaging.json.Embed;
-import org.bukkit.entity.Player;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.player.PlayerAdvancementDoneEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
-import org.bukkit.event.player.PlayerLoginEvent;
-import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerRespawnEvent.RespawnReason;
-import org.bukkit.event.player.PlayerTeleportEvent;
-import org.bstats.charts.SimplePie;
+
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
-import java.util.logging.Logger;
-
 public class DiscordPlayerHandler extends MessageHandler implements PlayerHandlerInterface {
 
   private final Gson gson = new Gson();
-  private DiscordMessageFactory messageFactory;
+  private final DiscordMessageFactory messageFactory;
 
   public DiscordPlayerHandler(DiscordMessageFactory messageFactory, Localizer localizer) {
     super(localizer);
@@ -72,7 +74,7 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   @Override
   public void playerFailedLogin(PlayerLoginEvent event, ELConfig config, Logger logger) {
     Embed embed = new Embed(config.getDiscordColor("playerFailedLogin"));
-    embed.setTitle("Tried to Log in");
+    embed.setTitle(localizer.t("discord.player.attempted_login_title"));
     embed.addAuthor(event.getPlayer().getName(), config.getMCUserAvatarUrl(event.getPlayer().getUniqueId().toString()));
     embed.setDescription(((TextComponent) event.kickMessage()).content());
     DiscordMessage message = messageFactory.getMessage(embed);
@@ -87,17 +89,17 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   @Override
   public void playerJoin(Player player, ELConfig config) {
     Embed embed = new Embed(config.getDiscordColor("playerJoin"));
-    embed.setTitle("Joined Server");
+    embed.setTitle(localizer.t("discord.player.joined_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
-    embed.addField("NAME", player.getName());
-    embed.addField("OP", Boolean.toString(player.isOp()));
-    embed.addField("LEVEL", Integer.toString(player.getLevel()));
-    embed.addField("ADDRESS", player.getAddress().getHostName());
-    embed.addField("EXP", Integer.toString(player.getTotalExperience()));
-    embed.addField("XYZ", StringUtils.getLocationString(player.getLocation()));
-    embed.addField("ONLINE PLAYERS", Integer.toString(player.getServer().getOnlinePlayers().size()));
-    embed.addField("WORLD", player.getWorld().getName());
-    embed.addField("GAME MODE", player.getGameMode().toString());
+    embed.addField(localizer.t("name"), player.getName());
+    embed.addField(localizer.t("op"), Boolean.toString(player.isOp()));
+    embed.addField(localizer.t("level"), Integer.toString(player.getLevel()));
+    embed.addField(localizer.t("address"), player.getAddress().getHostName());
+    embed.addField(localizer.t("exp"), Integer.toString(player.getTotalExperience()));
+    embed.addField(localizer.t("xyz"), StringUtils.getLocationString(player.getLocation()));
+    embed.addField(localizer.t("online_players"), Integer.toString(player.getServer().getOnlinePlayers().size()));
+    embed.addField(localizer.t("world"), player.getWorld().getName());
+    embed.addField(localizer.t("game_mode"), player.getGameMode().toString());
     embed.setImage(config.getMCUserBustUrl(player.getUniqueId().toString()));
     DiscordMessage message = messageFactory.getMessage(embed);
 
@@ -117,12 +119,11 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   @Override
   public void playerLeave(Player player, ELConfig config) {
     long count = player.getServer().getOnlinePlayers().size() - 1;
-    String content = "Online count: **" + count + "/" + player.getServer().getMaxPlayers() + "**";
 
     Embed embed = new Embed(config.getDiscordColor("playerLeave"));
-    embed.setTitle("Left Server");
+    embed.setTitle(localizer.t("discord.player.left_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
-    embed.setDescription(content);
+    embed.setDescription(localizer.t("discord.player.leave_template", count, player.getServer().getMaxPlayers()));
     DiscordMessage message = messageFactory.getMessage(embed);
 
     Logger logger = player.getServer().getPluginManager().getPlugin(config.getPluginName()).getLogger();
@@ -137,7 +138,7 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   public void playerChat(AsyncChatEvent event, ELConfig config) {
     Player player = event.getPlayer();
     Embed embed = new Embed(config.getDiscordColor("playerChat"));
-    embed.setTitle("Said in Chat");
+    embed.setTitle(localizer.t("discord.player.chat_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
     embed.setDescription(((TextComponent) event.message()).content());
     DiscordMessage message = messageFactory.getMessage(embed);
@@ -155,7 +156,7 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   public void playerCommand(PlayerCommandPreprocessEvent event, ELConfig config) {
     Player player = event.getPlayer();
     Embed embed = new Embed(config.getDiscordColor("playerCommand"));
-    embed.setTitle("Issued Command");
+    embed.setTitle(localizer.t("discord.player.command_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
     embed.setDescription("`" + event.getMessage() + "`");
     DiscordMessage message = messageFactory.getMessage(embed);
@@ -175,9 +176,9 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
     if (!event.getAdvancement().getKey().getKey().startsWith("recipes")) {
       Player player = event.getPlayer();
       Embed embed = new Embed(config.getDiscordColor("playerAdvancement"));
-      embed.setTitle("Made Advancement");
+      embed.setTitle(localizer.t("discord.player.advancement_title"));
       embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
-      String advancementKey = event.getAdvancement().getKey().getKey().toString();
+      String advancementKey = event.getAdvancement().getKey().getKey();
       embed.setDescription("`"
           + advConfig.getAdvancementTitle(advancementKey) + "`\n(_"
           + advConfig.getAdvancementDescription(advancementKey)
@@ -197,7 +198,7 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
   public void playerDeath(PlayerDeathEvent event, ELConfig config) {
     Player player = event.getEntity();
     Embed embed = new Embed(config.getDiscordColor("playerDeath"));
-    embed.setTitle("Died");
+    embed.setTitle(localizer.t("discord.player.died_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
     String deathMessage = (String) LegacyComponentSerializer.legacySection().serializeOrNull(event.deathMessage());
     embed.setDescription(deathMessage);
@@ -216,9 +217,10 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
     Player player = event.getPlayer();
     RespawnReason reason = event.getRespawnReason();
     Embed embed = new Embed(config.getDiscordColor("playerRespawn"));
-    embed.setTitle("Respawned");
+    embed.setTitle(localizer.t("discord.player.respawned_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
-    embed.setDescription(player.getName() + " respawned due to " + reason.toString() + ".");
+    embed.setDescription(localizer.t("discord.player.respawned_template",
+        player.getName(), reason.toString()));
     DiscordMessage message = messageFactory.getMessage(embed);
 
     Logger logger = player.getServer().getPluginManager().getPlugin(config.getPluginName()).getLogger();
@@ -238,10 +240,10 @@ public class DiscordPlayerHandler extends MessageHandler implements PlayerHandle
     }
     Player player = event.getPlayer();
     Embed embed = new Embed(config.getDiscordColor("playerTeleport"));
-    embed.setTitle("Teleported");
+    embed.setTitle(localizer.t("discord.player.teleported_title"));
     embed.addAuthor(player.getName(), config.getMCUserAvatarUrl(player.getUniqueId().toString()));
-    embed.setDescription("From: **" + fromLoc + "** To: **" + toLoc + "** \nReason: **"
-        + event.getCause().toString() + "**");
+    embed.setDescription(localizer.t("discord.player.teleported_template",
+        player.getName(), fromLoc, toLoc, event.getCause().toString()));
     DiscordMessage message = messageFactory.getMessage(embed);
 
     Logger logger = player.getServer().getPluginManager().getPlugin(config.getPluginName()).getLogger();

--- a/src/main/java/com/hidethemonkey/elfim/messaging/DiscordServerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/DiscordServerHandler.java
@@ -23,7 +23,20 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.event.server.BroadcastMessageEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.plugin.Plugin;
+
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.hidethemonkey.elfim.ELConfig;
 import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.NetworkUtils;
@@ -32,23 +45,12 @@ import com.hidethemonkey.elfim.messaging.json.DiscordMessage;
 import com.hidethemonkey.elfim.messaging.json.DiscordMessageFactory;
 import com.hidethemonkey.elfim.messaging.json.Embed;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Server;
-import org.bukkit.event.server.BroadcastMessageEvent;
-import org.bukkit.event.server.ServerCommandEvent;
-import org.bukkit.plugin.Plugin;
-
 import net.kyori.adventure.text.TextComponent;
-
-import java.io.FileInputStream;
-import java.util.List;
-import java.util.Properties;
-import java.util.logging.Logger;
 
 public class DiscordServerHandler extends MessageHandler implements ServerHandlerInterface {
 
-  private final Gson gson = new Gson();
-  private DiscordMessageFactory messageFactory;
+  private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+  private final DiscordMessageFactory messageFactory;
 
   public DiscordServerHandler(DiscordMessageFactory messageFactory, Localizer localizer) {
     super(localizer);
@@ -102,7 +104,7 @@ public class DiscordServerHandler extends MessageHandler implements ServerHandle
         message.addEmbed(pluginEmbed);
       }
       List<String> logProperties = config.getLogProperties();
-      if (logProperties.size() > 0) {
+      if (!logProperties.isEmpty()) {
         Embed propertiesEmbed = new Embed(config.getDiscordColor("serverProperties"));
         propertiesEmbed.setTitle(String.format("**%s**", localizer.t("server_properties")));
         Properties props = new Properties();
@@ -115,9 +117,8 @@ public class DiscordServerHandler extends MessageHandler implements ServerHandle
             }
             propertiesEmbed.addField(key, value);
           }
-        } catch (Exception e) {
+        } catch (IOException e) {
           propertiesEmbed.addField(localizer.t("error"), e.getLocalizedMessage());
-          e.printStackTrace();
         }
 
         message.addEmbed(propertiesEmbed);
@@ -140,7 +141,7 @@ public class DiscordServerHandler extends MessageHandler implements ServerHandle
             + "](https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest))"
         : "";
     Embed embed = new Embed(config.getDiscordColor("serverShutdown"));
-    embed.setTitle("**Server Stopping**");
+    embed.setTitle(localizer.t("server_stopping"));
     embed.addField(localizer.t("motd"), ((TextComponent) server.motd()).content());
     embed.addField(localizer.t("type"), server.getName());
     embed.addField(localizer.t("version"), server.getVersion());

--- a/src/main/java/com/hidethemonkey/elfim/messaging/MessageHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/MessageHandler.java
@@ -23,21 +23,26 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
-import com.hidethemonkey.elfim.helpers.Localizer;
-import com.slack.api.Slack;
-import com.slack.api.SlackConfig;
-import com.slack.api.model.block.LayoutBlock;
-import okhttp3.*;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.hidethemonkey.elfim.helpers.Localizer;
+import com.slack.api.Slack;
+import com.slack.api.SlackConfig;
+import com.slack.api.model.block.LayoutBlock;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
 public abstract class MessageHandler {
 
   private final Slack slack = Slack.getInstance(new SlackConfig());
-  private final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+  private final MediaType JSON = MediaType.get("application/json; charset=utf-8" );
   private final OkHttpClient client = new OkHttpClient();
   protected final Localizer localizer;
 

--- a/src/main/java/com/hidethemonkey/elfim/messaging/MessageHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/MessageHandler.java
@@ -23,6 +23,7 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
+import com.hidethemonkey.elfim.helpers.Localizer;
 import com.slack.api.Slack;
 import com.slack.api.SlackConfig;
 import com.slack.api.model.block.LayoutBlock;
@@ -38,6 +39,16 @@ public abstract class MessageHandler {
   private final Slack slack = Slack.getInstance(new SlackConfig());
   private final MediaType JSON = MediaType.get("application/json; charset=utf-8");
   private final OkHttpClient client = new OkHttpClient();
+  protected final Localizer localizer;
+
+  /**
+   * Constructor for MessageHandler passing the Localizer
+   * 
+   * @param localizer
+   */
+  public MessageHandler(Localizer localizer) {
+    this.localizer = localizer;
+  }
 
   /**
    * @param url

--- a/src/main/java/com/hidethemonkey/elfim/messaging/SlackPlayerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/SlackPlayerHandler.java
@@ -23,28 +23,30 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
-import com.hidethemonkey.elfim.AdvancementConfig;
-import com.hidethemonkey.elfim.ELConfig;
-import com.hidethemonkey.elfim.ELFIM;
-import com.hidethemonkey.elfim.helpers.Localizer;
-import com.hidethemonkey.elfim.helpers.StringUtils;
-import com.slack.api.model.block.LayoutBlock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.bstats.charts.SimplePie;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerRespawnEvent.RespawnReason;
-import org.bstats.charts.SimplePie;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import com.hidethemonkey.elfim.AdvancementConfig;
+import com.hidethemonkey.elfim.ELConfig;
+import com.hidethemonkey.elfim.ELFIM;
+import com.hidethemonkey.elfim.helpers.Localizer;
+import com.hidethemonkey.elfim.helpers.StringUtils;
+import com.slack.api.model.block.LayoutBlock;
+
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
 
 public class SlackPlayerHandler extends MessageHandler implements PlayerHandlerInterface {
 
@@ -102,8 +104,10 @@ public class SlackPlayerHandler extends MessageHandler implements PlayerHandlerI
 
     // Track player locale
     ELFIM plugin = (ELFIM) player.getServer().getPluginManager().getPlugin(config.getPluginName());
-    plugin.getMetrics().addCustomChart(
-        new SimplePie("player_locale", () -> player.locale().toString()));
+    if (plugin != null) {
+      plugin.getMetrics().addCustomChart(
+          new SimplePie("player_locale", () -> player.locale().toString()));
+    }
   }
 
   /**
@@ -163,7 +167,7 @@ public class SlackPlayerHandler extends MessageHandler implements PlayerHandlerI
   public void playerAdvancement(
       PlayerAdvancementDoneEvent event, ELConfig config, AdvancementConfig advConfig) {
     if (!event.getAdvancement().getKey().getKey().startsWith("recipes")) {
-      String advancementKey = event.getAdvancement().getKey().getKey().toString();
+      String advancementKey = event.getAdvancement().getKey().getKey();
       String message = localizer.t("slack.player.advancement_template", event.getPlayer().getName(),
           advConfig.getAdvancementTitle(advancementKey), advConfig.getAdvancementDescription(advancementKey));
       postMessage(message, config.getSlackChannelId(), config.getSlackAPIToken());

--- a/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
@@ -24,6 +24,7 @@
 package com.hidethemonkey.elfim.messaging;
 
 import com.hidethemonkey.elfim.ELConfig;
+import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.NetworkUtils;
 import com.hidethemonkey.elfim.helpers.StringUtils;
 import com.slack.api.model.block.ContextBlockElement;
@@ -46,6 +47,10 @@ import java.util.logging.Logger;
 
 public class SlackServerHandler extends MessageHandler implements ServerHandlerInterface {
 
+  public SlackServerHandler(Localizer localizer) {
+    super(localizer);
+  }
+
   /**
    *
    * @return
@@ -62,23 +67,31 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
    */
   @Override
   public void startup(Server server, ELConfig config, boolean logPlugins) {
-    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader("Server Started");
+    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader(localizer.t("server_started"));
     String pluginVersion = server.getPluginManager().getPlugin(config.getPluginName()).getPluginMeta().getVersion();
-    String updateAvailable = ELConfig.getUpdateAvailable() ? " (<https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest|update available>)" : "";
+    String updateAvailable = ELConfig.getUpdateAvailable()
+        ? " (<https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest|" + localizer.t("update_available")
+            + ">)"
+        : "";
     blocks.add(
         BlockBuilder.getContextBlock(
-            BlockBuilder.getMarkdown("*MOTD:* " + ((TextComponent) server.motd()).content()),
-            BlockBuilder.getMarkdown("*TYPE:* " + server.getName()),
-            BlockBuilder.getMarkdown("*VERSION:* " + server.getVersion()),
-            BlockBuilder.getMarkdown("*MAX PLAYERS:* " + server.getMaxPlayers()),
-            BlockBuilder.getMarkdown("*GAME MODE:* " + server.getDefaultGameMode()),
-            BlockBuilder.getMarkdown("*LOCAL IP:* " + NetworkUtils.getLocalIP(server.getIp())),
-            BlockBuilder.getMarkdown("*EXTERNAL IP:* " + NetworkUtils.getExternalIP()),
-            BlockBuilder.getMarkdown("*ELFIM VERSION:* " + pluginVersion + updateAvailable)));
+            BlockBuilder
+                .getMarkdown(String.format("*%s:* %s", localizer.t("motd"), ((TextComponent) server.motd()).content())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("type"), server.getName())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("version"), server.getVersion())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %d", localizer.t("max_players"), server.getMaxPlayers())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("game_mode"), server.getDefaultGameMode())),
+            BlockBuilder.getMarkdown(
+                String.format("*%s:* %s", localizer.t("local_ip"), NetworkUtils.getLocalIP(server.getIp()))),
+            BlockBuilder
+                .getMarkdown(String.format("*%s:* %s", localizer.t("external_ip"), NetworkUtils.getExternalIP())),
+            BlockBuilder
+                .getMarkdown(
+                    String.format("*%s:* %s", localizer.t("elfim_version"), pluginVersion + updateAvailable))));
 
     String serverName = ((TextComponent) server.motd()).content().isBlank() ? server.getName()
         : ((TextComponent) server.motd()).content();
-    String message = "Minecraft server `" + serverName + "` is now online.";
+    String message = localizer.t("slack.server_online", serverName);
     postBlocks(blocks, message, config.getSlackChannelId(), config.getSlackAPIToken());
     try {
       // give it some time to post before listing plugins and properties
@@ -89,12 +102,12 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
     if (logPlugins) {
       // delay task to ensure the plugins are fully loaded so we get an accurate state
       Bukkit.getScheduler().runTaskLater(server.getPluginManager().getPlugin(config.getPluginName()), task -> {
-          listPlugins(server.getPluginManager(), config);
+        listPlugins(server.getPluginManager(), config);
       }, 1);
     }
     List<String> logProperties = config.getLogProperties();
     if (logProperties.size() > 0) {
-      listPproperties(server.getPluginManager(), config, logProperties);
+      listProperties(server.getPluginManager(), config, logProperties);
     }
   }
 
@@ -104,26 +117,30 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
    */
   @Override
   public void shutdown(Server server, ELConfig config) {
-    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader("Server Stopping");
+    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader(localizer.t("server_stopping"));
     String pluginVersion = server.getPluginManager().getPlugin(config.getPluginName()).getPluginMeta().getVersion();
-    String updateAvailable = ELConfig.getUpdateAvailable() ? " (<https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest|update available>)" : "";
+    String updateAvailable = ELConfig.getUpdateAvailable()
+        ? " (<https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest|" + localizer.t("update_available")
+            + ">)"
+        : "";
     blocks.add(
         BlockBuilder.getContextBlock(
-            BlockBuilder.getMarkdown("*MOTD:* " + ((TextComponent) server.motd()).content()),
-            BlockBuilder.getMarkdown("*TYPE:* " + server.getName()),
-            BlockBuilder.getMarkdown("*VERSION:* " + server.getVersion()),
-            BlockBuilder.getMarkdown("*ONLINE PLAYERS:* " + server.getOnlinePlayers().size()),
-            BlockBuilder.getMarkdown("*GAME MODE:* " + server.getDefaultGameMode()),
-            BlockBuilder.getMarkdown("*ELFIM VERSION:* " + pluginVersion + updateAvailable)));
+            BlockBuilder
+                .getMarkdown(String.format("*%s:* %s", localizer.t("motd"), ((TextComponent) server.motd()).content())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("type"), server.getName())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("version"), server.getVersion())),
+            BlockBuilder
+                .getMarkdown(
+                    String.format("*%s:* %d", localizer.t("online_players"), server.getOnlinePlayers().size())),
+            BlockBuilder.getMarkdown(String.format("*%s:* %s", localizer.t("game_mode"), server.getDefaultGameMode())),
+            BlockBuilder
+                .getMarkdown(
+                    String.format("*%s:* %s", localizer.t("elfim_version"), pluginVersion + updateAvailable))));
 
     String serverName = ((TextComponent) server.motd()).content().isBlank() ? server.getName()
         : ((TextComponent) server.motd()).content();
-    String message = "`"
-        + serverName
-        + "` is shutting down! Players still online: *"
-        + server.getOnlinePlayers().size()
-        + "*";
-    postBlocks(blocks, message, config.getSlackChannelId(), config.getSlackAPIToken());
+    postBlocks(blocks, localizer.t("server_shutdown", serverName, server.getOnlinePlayers().size()),
+        config.getSlackChannelId(), config.getSlackAPIToken());
   }
 
   /**
@@ -132,20 +149,21 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
    */
   private void listPlugins(PluginManager manager, ELConfig config) {
     Plugin[] plugins = manager.getPlugins();
-    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader("Installed Plugins");
+    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader(localizer.t("installed_plugins"));
     ArrayList<ContextBlockElement> list = new ArrayList<>();
     for (Plugin plugin : plugins) {
-      String disabledString = plugin.isEnabled() ? ": " : " [_disabled_]: ";
-      list.add(BlockBuilder.getMarkdown("*" + plugin.getName() + "*" + disabledString + plugin.getPluginMeta().getVersion()));
+      String disabledString = plugin.isEnabled() ? ": " : String.format(" [_%s_]: ", localizer.t("disabled"));
+      list.add(BlockBuilder
+          .getMarkdown("*" + plugin.getName() + "*" + disabledString + plugin.getPluginMeta().getVersion()));
     }
     blocks.add(BlockBuilder.getContextBlock(list));
-    postBlocks(blocks, "List of plugins", config.getSlackChannelId(), config.getSlackAPIToken());
+    postBlocks(blocks, localizer.t("list_of_plugins"), config.getSlackChannelId(), config.getSlackAPIToken());
   }
 
-  private void listPproperties(PluginManager manager, ELConfig config, List<String> properties) {
+  private void listProperties(PluginManager manager, ELConfig config, List<String> properties) {
     Properties props = new Properties();
     ArrayList<ContextBlockElement> list = new ArrayList<>();
-    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader("Server Properties");
+    List<LayoutBlock> blocks = BlockBuilder.getListBlocksWithHeader(localizer.t("server_properties"));
 
     try {
       props.load(new FileInputStream("server.properties"));
@@ -153,12 +171,12 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
         list.add(BlockBuilder.getMarkdown("*" + key + ":* " + props.getProperty(key)));
       }
     } catch (Exception e) {
-      list.add(BlockBuilder.getMarkdown("Error loading server.properties: " + e.getLocalizedMessage()));
+      list.add(BlockBuilder.getMarkdown(localizer.t("server.error_loading_properties", e.getLocalizedMessage())));
       e.printStackTrace();
     }
 
     blocks.add(BlockBuilder.getContextBlock(list));
-    postBlocks(blocks, "List of properties", config.getSlackChannelId(), config.getSlackAPIToken());
+    postBlocks(blocks, localizer.t("server.list_of_properties"), config.getSlackChannelId(), config.getSlackAPIToken());
   }
 
   /**
@@ -168,8 +186,8 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
    */
   @Override
   public void serverCommand(ServerCommandEvent event, ELConfig config, Logger logger) {
-    String message = "*" + event.getSender().getName() + "* issued server command: `" + event.getCommand() + "`";
-    postMessage(message, config.getSlackChannelId(), config.getSlackAPIToken());
+    postMessage(localizer.t("server.issued_command", event.getSender().getName(), event.getCommand()),
+        config.getSlackChannelId(), config.getSlackAPIToken());
   }
 
   /**
@@ -179,7 +197,9 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
    */
   @Override
   public void broadcastChat(BroadcastMessageEvent event, ELConfig config, Logger logger) {
-    String message = "*[BROADCAST]* " + StringUtils.removeSpecialChars(((TextComponent) event.message()).content());
+    String message = String.format("*[%s]* ",
+        localizer.t("server.broadcast_message")
+            + StringUtils.removeSpecialChars(((TextComponent) event.message()).content()));
     postMessage(message, config.getSlackChannelId(), config.getSlackAPIToken());
   }
 }

--- a/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
@@ -197,8 +197,8 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
   @Override
   public void broadcastChat(BroadcastMessageEvent event, ELConfig config, Logger logger) {
     String message = String.format("*[%s]* ",
-        localizer.t("server.broadcast_message")
-            + StringUtils.removeSpecialChars(((TextComponent) event.message()).content()));
+        localizer.t("server.broadcast_message",
+            StringUtils.removeSpecialChars(((TextComponent) event.message()).content())));
     postMessage(message, config.getSlackChannelId(), config.getSlackAPIToken());
   }
 }

--- a/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
+++ b/src/main/java/com/hidethemonkey/elfim/messaging/SlackServerHandler.java
@@ -23,6 +23,20 @@
  */
 package com.hidethemonkey.elfim.messaging;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.event.server.BroadcastMessageEvent;
+import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
 import com.hidethemonkey.elfim.ELConfig;
 import com.hidethemonkey.elfim.helpers.Localizer;
 import com.hidethemonkey.elfim.helpers.NetworkUtils;
@@ -30,20 +44,7 @@ import com.hidethemonkey.elfim.helpers.StringUtils;
 import com.slack.api.model.block.ContextBlockElement;
 import com.slack.api.model.block.LayoutBlock;
 
-import org.bukkit.Server;
-import org.bukkit.Bukkit;
-import org.bukkit.event.server.BroadcastMessageEvent;
-import org.bukkit.event.server.ServerCommandEvent;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginManager;
-
 import net.kyori.adventure.text.TextComponent;
-
-import java.io.FileInputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Properties;
-import java.util.logging.Logger;
 
 public class SlackServerHandler extends MessageHandler implements ServerHandlerInterface {
 
@@ -97,7 +98,6 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
       // give it some time to post before listing plugins and properties
       Thread.sleep(100);
     } catch (InterruptedException e) {
-      e.printStackTrace();
     }
     if (logPlugins) {
       // delay task to ensure the plugins are fully loaded so we get an accurate state
@@ -170,9 +170,8 @@ public class SlackServerHandler extends MessageHandler implements ServerHandlerI
       for (String key : properties) {
         list.add(BlockBuilder.getMarkdown("*" + key + ":* " + props.getProperty(key)));
       }
-    } catch (Exception e) {
+    } catch (IOException e) {
       list.add(BlockBuilder.getMarkdown(localizer.t("server.error_loading_properties", e.getLocalizedMessage())));
-      e.printStackTrace();
     }
 
     blocks.add(BlockBuilder.getContextBlock(list));

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,7 +6,7 @@ MCUserAvatarUrl: https://crafthead.net/avatar/
 MCUserBustUrl: https://crafthead.net/bust/
 
 # Specify the locale to use for messages (NOTE: must have a corresponding locale file in the plugin config folder)
-# example: ./plugins/EventLoggerForIM/i18n/en_US.properties or ./plugins/EventLoggerForIM/i18n/en.properties
+# example: ./plugins/EventLoggerForIM/i18n/en_US.properties or ./plugins/EventLoggerForIM/i18n/de.properties
 locale: en_US
 
 # enable or disable anonymous statistics collection with bStats.org

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,10 @@ enableDiscord: false
 MCUserAvatarUrl: https://crafthead.net/avatar/
 MCUserBustUrl: https://crafthead.net/bust/
 
+# Specify the locale to use for messages (NOTE: must have a corresponding locale file in the plugin config folder)
+# example: ./plugins/EventLoggerForIM/i18n/en_US.properties or ./plugins/EventLoggerForIM/i18n/en.properties
+locale: en_US
+
 # enable or disable anonymous statistics collection with bStats.org
 # Please consider leaving this on. It doesn't collect any personal info
 # and it helps me keep track of overall usage patterns.

--- a/src/main/resources/i18n/de.properties
+++ b/src/main/resources/i18n/de.properties
@@ -1,0 +1,82 @@
+# General
+address=ADRESSE
+elfim_version=ELFIM VERSION
+error=Fehler
+exp=EXP
+external_ip=EXTERNE IP
+game_mode=SPIELMODUS
+level=LEVEL
+local_ip=LOKALE IP
+max_players=MAX SPIELER
+motd=MOTD
+name=NAME
+online_players=ONLINE SPIELER
+op=OP
+type=TYP
+update_available=update verfügbar
+version=VERSION
+world=WELT
+xyz=XYZ
+
+metrics.info.not_enabled=bStats ist nicht aktiviert! Bitte ziehen sie in betracht, diesen dienst zu aktivieren, um mir zu helfen, die nutzung von ELFIM zu verfolgen. 🙇
+version.check_failed=Überprüfen neuer versionen fehlgeschlagen. Bitte siehe https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest für Updates.
+version.download_link=Hier herunterladen: %s
+version.new_release_available=Eine neue Version von EventLoggerForIM ist verfügbar!
+version.new_version=Neue Version: %s
+version.please_update=Bitte aktualisieren Sie, um die neuesten Funktionen und Fehlerbehebungen zu nutzen.
+version.your_version=Ihre Version: %s
+
+# Slack
+slack.error.channel_not_set=Der Slack-Kanal muss in /plugin/EventLoggerForIM/config.yml festgelegt werden!
+slack.error.token_not_set=Das Slack-API-Token muss in /plugin/EventLoggerForIM/config.yml festgelegt werden!
+slack.info.not_enabled=Slack-Integration ist nicht aktiviert.
+slack.player.advancement_template=*%s* hat die errungenschaft `%s` gemacht\n(_%s_)
+slack.player.attempted_login=*%s* hat versucht, sich anzumelden.\n%s
+slack.player.body.respawn_template=%s ist respawnt.
+slack.player.chat_template=*%s* sagte: %s
+slack.player.command_template=*%s* hat den befehl ausgeführt: `%s`
+slack.player.header.died=Spieler Gestorben
+slack.player.header.joined=Spieler Beigetreten
+slack.player.header.left=Spieler Verlassen
+slack.player.header.respawned=Spieler Respawnt
+slack.player.joined_template=%s ist dem server beigetreten.
+slack.player.leave_template=*%s* hat den server verlassen! Online-Zahl: *%d/%d*
+slack.player.respawned_template=%s ist respawnt aufgrund von %s.
+slack.player.teleported_template=*%s* teleportiert von *%s* nach *%s*.\nGrund: *%s*
+slack.server_online=Minecraft Server `%s` ist jetzt online.
+slack.warn.api_not_configured=Das Slack-API-Token oder der kanal ist nicht konfiguriert!
+
+# Discord
+discord.info.not_enabled=Discord integration ist nicht aktiviert.
+discord.player.advancement_title=Errungenschaft gemacht
+discord.player.attempted_login_title=Versuch, sich anzumelden
+discord.player.chat_title=In chat gesagt
+discord.player.command_title=Ausgeführter Befehl
+discord.player.died_title=Spieler Gestorben
+discord.player.joined_title=Spieler Beigetreten
+discord.player.left_title=Spieler Verlassen
+discord.player.leave_template=Online-Zahl: **%d/%d**
+discord.player.respawned_template=%s ist respawnt aufgrund von %s.
+discord.player.respawned_title=Spieler Respawnt
+discord.player.teleported_template=*%s* teleportiert von *%s* nach *%s*.\nGrund: *%s*
+discord.player.teleported_title=Spieler Teleportiert
+discord.warn.api_not_configured=Discord integration ist nicht aktiviert.
+
+# Common Player Messages
+player.banned=*%s* wurde vom spiel ausgeschlossen.
+player.joined=Spieler Beigetreten
+player.kicked=*%s* wurde aus dem spiel geworfen.
+player.left=*%s* hat das spiel verlassen.
+
+# Common Server Messages
+disabled=deaktiviert
+installed_plugins=Installierte Plugins
+list_of_plugins=Liste der Plugins
+server.broadcast_message=Broadcast Nachricht
+server.error_loading_properties=Fehler beim laden von server.properties: %s
+server.issued_command=*%s* hat den befehl ausgeführt: `%s`
+server.list_of_properties=Liste der Eigenschaften
+server_properties=Server Eigenschaften
+server_shutdown=%s wird heruntergefahren! Spieler sind noch online: *%d*
+server_started=Server Gestartet
+server_stopping=Server wird Gestoppt

--- a/src/main/resources/i18n/de.properties
+++ b/src/main/resources/i18n/de.properties
@@ -18,7 +18,7 @@ version=VERSION
 world=WELT
 xyz=XYZ
 
-metrics.info.not_enabled=bStats ist nicht aktiviert! Bitte ziehen sie in betracht, diesen dienst zu aktivieren, um mir zu helfen, die nutzung von ELFIM zu verfolgen. 🙇
+metrics.info.not_enabled=bStats ist nicht aktiviert! Bitte ziehen Sie in betracht, diesen dienst zu aktivieren, um mir zu helfen, die nutzung von ELFIM zu verfolgen. 🙇
 version.check_failed=Überprüfen neuer versionen fehlgeschlagen. Bitte siehe https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest für Updates.
 version.download_link=Hier herunterladen: %s
 version.new_release_available=Eine neue Version von EventLoggerForIM ist verfügbar!

--- a/src/main/resources/i18n/de.properties
+++ b/src/main/resources/i18n/de.properties
@@ -44,7 +44,7 @@ slack.player.leave_template=*%s* hat den server verlassen! Online-Zahl: *%d/%d*
 slack.player.respawned_template=%s ist respawnt aufgrund von %s.
 slack.player.teleported_template=*%s* teleportiert von *%s* nach *%s*.\nGrund: *%s*
 slack.server_online=Minecraft Server `%s` ist jetzt online.
-slack.warn.api_not_configured=Das Slack-API-Token oder der kanal ist nicht konfiguriert!
+slack.warn.api_not_configured=Das Slack-API-Token oder der Kanal ist nicht konfiguriert!
 
 # Discord
 discord.info.not_enabled=Discord integration ist nicht aktiviert.

--- a/src/main/resources/i18n/en_US.properties
+++ b/src/main/resources/i18n/en_US.properties
@@ -20,51 +20,63 @@ xyz=XYZ
 
 metrics.info.not_enabled=bStats is not enabled! Please consider activating this service to help me keep track of ELFIM usage. 🙇
 version.check_failed=Could not check for new versions. Please see https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest for updates.
+version.download_link=Download here: %s
 version.new_release_available=A new release of EventLoggerForIM is available!
 version.new_version=New version: %s
-version.your_version=Your version: %s
 version.please_update=Please update to take advantage of the latest features and bug fixes.
-version.download_link=Download here: %s
+version.your_version=Your version: %s
 
 # Slack
-slack.info.not_enabled=Slack integration is not enabled.
-slack.warn.api_not_configured=The Slack API token or channel is not configured!
 slack.error.channel_not_set=The Slack channel must be set in /plugin/EventLoggerForIM/config.yml!
 slack.error.token_not_set=The Slack API token must be set in /plugin/EventLoggerForIM/config.yml!
-slack.server_online=Minecraft server `%s` is now online.
+slack.info.not_enabled=Slack integration is not enabled.
+slack.player.advancement_template=*%s* has made the advancement `%s`\n(_%s_)
 slack.player.attempted_login=*%s* attempted to log in.\n%s
-slack.player.joined_template=%s joined the server.
-slack.player.header.joined=Player Joined
-slack.player.header.left=Player Left
-slack.player.leave_template=*%s* left the server! Online count: *%d/%d*
+slack.player.body.respawn_template=%s respawned.
 slack.player.chat_template=*%s* said: %s
 slack.player.command_template=*%s* issued command: `%s`
-slack.player.advancement_template=*%s* has made the advancement `%s`\n(_%s_)
 slack.player.header.died=Player Died
+slack.player.header.joined=Player Joined
+slack.player.header.left=Player Left
 slack.player.header.respawned=Player Respawned
-slack.player.body.respawn_template=%s respawned.
+slack.player.joined_template=%s joined the server.
+slack.player.leave_template=*%s* left the server! Online count: *%d/%d*
 slack.player.respawned_template=%s respawned due to %s.
 slack.player.teleported_template=*%s* teleported from *%s* to *%s*.\nReason: *%s*
+slack.server_online=Minecraft server `%s` is now online.
+slack.warn.api_not_configured=The Slack API token or channel is not configured!
 
 # Discord
 discord.info.not_enabled=Discord integration is not enabled.
+discord.player.advancement_title=Made Advancement
+discord.player.attempted_login_title=Tried to Log In
+discord.player.chat_title=Said in Chat
+discord.player.command_title=Issued Command
+discord.player.died_title=Player Died
+discord.player.joined_title=Joined Server
+discord.player.left_title=Left Server
+discord.player.leave_template=Online count: **%d/%d**
+discord.player.respawned_template=%s respawned due to %s.
+discord.player.respawned_title=Player Respawned
+discord.player.teleported_template=*%s* teleported from *%s* to *%s*.\nReason: *%s*
+discord.player.teleported_title=Player Teleported
 discord.warn.api_not_configured=Discord integration is not enabled.
 
 # Common Player Messages
-player.joined=Player Joined
-player.left=*%s* left the game.
-player.kicked=*%s* was kicked from the game.
 player.banned=*%s* was banned from the game.
+player.joined=Player Joined
+player.kicked=*%s* was kicked from the game.
+player.left=*%s* left the game.
 
 # Common Server Messages
-server_started=Server Started
-server_properties=Server Properties
-server.list_of_properties=List of Properties
-server_stopping=Server Stopping
-server_shutdown=%s is shutting down! Players still online: *%d*
+disabled=disabled
 installed_plugins=Installed Plugins
 list_of_plugins=List of Plugins
-disabled=disabled
-server.error_loading_properties=Error loading server.properties: %s
 server.broadcast_message=Broadcast Message
+server.error_loading_properties=Error loading server.properties: %s
 server.issued_command=*%s* issued command: `%s`
+server.list_of_properties=List of Properties
+server_properties=Server Properties
+server_shutdown=%s is shutting down! Players still online: *%d*
+server_started=Server Started
+server_stopping=Server Stopping

--- a/src/main/resources/i18n/en_US.properties
+++ b/src/main/resources/i18n/en_US.properties
@@ -1,0 +1,70 @@
+# General
+address=ADDRESS
+elfim_version=ELFIM VERSION
+error=Error
+exp=EXP
+external_ip=EXTERNAL IP
+game_mode=GAME MODE
+level=LEVEL
+local_ip=LOCAL IP
+max_players=MAX PLAYERS
+motd=MOTD
+name=NAME
+online_players=ONLINE PLAYERS
+op=OP
+type=TYPE
+update_available=update available
+version=VERSION
+world=WORLD
+xyz=XYZ
+
+metrics.info.not_enabled=bStats is not enabled! Please consider activating this service to help me keep track of ELFIM usage. 🙇
+version.check_failed=Could not check for new versions. Please see https://github.com/HideTheMonkey/EventLoggerForIM/releases/latest for updates.
+version.new_release_available=A new release of EventLoggerForIM is available!
+version.new_version=New version: %s
+version.your_version=Your version: %s
+version.please_update=Please update to take advantage of the latest features and bug fixes.
+version.download_link=Download here: %s
+
+# Slack
+slack.info.not_enabled=Slack integration is not enabled.
+slack.warn.api_not_configured=The Slack API token or channel is not configured!
+slack.error.channel_not_set=The Slack channel must be set in /plugin/EventLoggerForIM/config.yml!
+slack.error.token_not_set=The Slack API token must be set in /plugin/EventLoggerForIM/config.yml!
+slack.server_online=Minecraft server `%s` is now online.
+slack.player.attempted_login=*%s* attempted to log in.\n%s
+slack.player.joined_template=%s joined the server.
+slack.player.header.joined=Player Joined
+slack.player.header.left=Player Left
+slack.player.leave_template=*%s* left the server! Online count: *%d/%d*
+slack.player.chat_template=*%s* said: %s
+slack.player.command_template=*%s* issued command: `%s`
+slack.player.advancement_template=*%s* has made the advancement `%s`\n(_%s_)
+slack.player.header.died=Player Died
+slack.player.header.respawned=Player Respawned
+slack.player.body.respawn_template=%s respawned.
+slack.player.respawned_template=%s respawned due to %s.
+slack.player.teleported_template=*%s* teleported from *%s* to *%s*.\nReason: *%s*
+
+# Discord
+discord.info.not_enabled=Discord integration is not enabled.
+discord.warn.api_not_configured=Discord integration is not enabled.
+
+# Common Player Messages
+player.joined=Player Joined
+player.left=*%s* left the game.
+player.kicked=*%s* was kicked from the game.
+player.banned=*%s* was banned from the game.
+
+# Common Server Messages
+server_started=Server Started
+server_properties=Server Properties
+server.list_of_properties=List of Properties
+server_stopping=Server Stopping
+server_shutdown=%s is shutting down! Players still online: *%d*
+installed_plugins=Installed Plugins
+list_of_plugins=List of Plugins
+disabled=disabled
+server.error_loading_properties=Error loading server.properties: %s
+server.broadcast_message=Broadcast Message
+server.issued_command=*%s* issued command: `%s`


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support to the ELFIM plugin, allowing users to select their preferred language for plugin messages. It adds a new `Localizer` helper class, updates the configuration and documentation to support translations, and refactors logging and messaging to use localized strings. The release is versioned as 2.3.0.

**Internationalization and Localization Support:**

* Added a new `Localizer` helper class to load and provide translated strings from UTF-8 `.properties` files, with fallback to English if a translation is missing. (`src/main/java/com/hidethemonkey/elfim/helpers/Localizer.java`)
* Updated the configuration to allow setting a `locale` option in `config.yml`, and added documentation in `README.md` on how to add new translations. (`README.md`, `src/main/java/com/hidethemonkey/elfim/ELConfig.java`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R68) [[3]](diffhunk://#diff-522b5849e36d2074ce3730ea77f280cf3373d35a4f53c0d979dd80bda07c79d3R273-R279)
* Bundled English (`en_US.properties`) and German (`de.properties`) translation files, and added logic to copy them on plugin startup. (`src/main/java/com/hidethemonkey/elfim/ELFIM.java`)

**Refactoring for Localized Messages:**

* Refactored all user-facing log messages and warnings in the main plugin class to use the `Localizer`, ensuring that messages respect the configured language. (`src/main/java/com/hidethemonkey/elfim/ELFIM.java`) [[1]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L85-R99) [[2]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L97-R108) [[3]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381R235-R240) [[4]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L294-R316) [[5]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L306-R328) [[6]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L345-R381)
* Updated message handler classes for Slack and Discord to accept a `Localizer` instance and use localized strings in messages sent to external services. (`src/main/java/com/hidethemonkey/elfim/messaging/DiscordPlayerHandler.java`, `src/main/java/com/hidethemonkey/elfim/ELFIM.java`) [[1]](diffhunk://#diff-d9f3dbb79e8b46fc3ff9901297793e6626aa3ebe7f9cd594233763de9acac753L26-R28) [[2]](diffhunk://#diff-d9f3dbb79e8b46fc3ff9901297793e6626aa3ebe7f9cd594233763de9acac753L42-R58) [[3]](diffhunk://#diff-d9f3dbb79e8b46fc3ff9901297793e6626aa3ebe7f9cd594233763de9acac753L73-R77) [[4]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L318-R343) [[5]](diffhunk://#diff-4253fa227666cbdbe654952a091b4eee3ad3dd1b23d9afc0f80933358d2b0381L332-R357)

**Documentation and Versioning:**

* Updated the `README.md` to document the new i18n feature, encourage translation contributions, and remove the "Internationalize / Localize text strings" item from the to-do list. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7-R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R56-R68) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76)
* Bumped the plugin version to 2.3.0 in `pom.xml` to reflect the new feature.

**Other Improvements:**

* Added reporting of the selected translation locale to bStats metrics. (`src/main/java/com/hidethemonkey/elfim/ELFIM.java`)
* Minor bugfix: Ensured HTTP client is closed in `VersionChecker`. (`src/main/java/com/hidethemonkey/elfim/helpers/VersionChecker.java`)